### PR TITLE
better handling if hub.challenge is missing from twitch

### DIFF
--- a/src/TwitchLib.Webhook/Filters/TwitchGetHeadRequestFilter.cs
+++ b/src/TwitchLib.Webhook/Filters/TwitchGetHeadRequestFilter.cs
@@ -49,8 +49,8 @@ namespace TwitchLib.Webhook.Filters
             RouteData routeData)
         {
             // Get the 'challenge' parameter from the request URI.
-            var challenge = request.Query[getHeadRequestMetadata.ChallengeQueryParameterName];
-   
+            if (!request.Query.TryGetValue(getHeadRequestMetadata.ChallengeQueryParameterName, out var challenge))
+                return new BadRequestObjectResult("hub.challenge not found in query parameters!");
 
             Logger.LogInformation(
                 403,
@@ -62,6 +62,10 @@ namespace TwitchLib.Webhook.Filters
             {
                 Content = challenge,
             };
+
+
+
+
         }
     }
 }

--- a/src/TwitchLib.Webhook/Filters/TwitchGetHeadRequestFilter.cs
+++ b/src/TwitchLib.Webhook/Filters/TwitchGetHeadRequestFilter.cs
@@ -50,7 +50,11 @@ namespace TwitchLib.Webhook.Filters
         {
             // Get the 'challenge' parameter from the request URI.
             if (!request.Query.TryGetValue(getHeadRequestMetadata.ChallengeQueryParameterName, out var challenge))
-                return new BadRequestObjectResult("hub.challenge not found in query parameters!");
+            {
+                Logger.LogInformation($"{getHeadRequestMetadata.ChallengeQueryParameterName} not found in query parameters!");
+                return new BadRequestObjectResult($"{getHeadRequestMetadata.ChallengeQueryParameterName} not found in query parameters!");
+            }
+                
 
             Logger.LogInformation(
                 403,


### PR DESCRIPTION
If for some reason twitch doesn't send hub.challenge, receiver responds back with missing information